### PR TITLE
chore(core,diagnose,eval,lex,parse,rope,syntax,typecheck): reduce uses of #[cfg(test)]

### DIFF
--- a/ipso-core/src/test.rs
+++ b/ipso-core/src/test.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 use crate::{Binop, Expr};
 
 #[test]

--- a/ipso-diagnostic/src/lib.rs
+++ b/ipso-diagnostic/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod test;
+
 use std::{
     collections::HashMap,
     fmt::Write as FmtWrite,
@@ -6,8 +9,6 @@ use std::{
     path::PathBuf,
     str::from_utf8,
 };
-
-mod test;
 
 #[derive(PartialEq, Eq, Debug, Hash, Clone)]
 pub enum Source {

--- a/ipso-diagnostic/src/test.rs
+++ b/ipso-diagnostic/src/test.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 use crate::{Diagnostic, Message};
 
 #[test]

--- a/ipso-eval/src/lib.rs
+++ b/ipso-eval/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod test;
 
 use ipso_core::{

--- a/ipso-eval/src/test.rs
+++ b/ipso-eval/src/test.rs
@@ -1,14 +1,8 @@
-#[cfg(test)]
 use super::{Interpreter, Value};
-#[cfg(test)]
 use crate::{Env, Object};
-#[cfg(test)]
 use ipso_core::{Builtin, CommonKinds, Expr, StringPart};
-#[cfg(test)]
 use ipso_syntax::Modules;
-#[cfg(test)]
 use std::collections::HashMap;
-#[cfg(test)]
 use typed_arena::Arena;
 
 #[test]

--- a/ipso-lex/src/test.rs
+++ b/ipso-lex/src/test.rs
@@ -1,11 +1,6 @@
-#[cfg(test)]
-use std::rc::Rc;
-
-#[cfg(test)]
 use super::Lexer;
-
-#[cfg(test)]
 use crate::token::{self, Token};
+use std::rc::Rc;
 
 #[test]
 fn lex_char_1() {

--- a/ipso-lex/src/token/mod.rs
+++ b/ipso-lex/src/token/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod test;
 
 use ipso_syntax::Keyword;

--- a/ipso-lex/src/token/test.rs
+++ b/ipso-lex/src/token/test.rs
@@ -1,9 +1,6 @@
-#[cfg(test)]
 use crate::token::Name;
-#[cfg(test)]
 use quickcheck_macros::quickcheck;
 
-#[cfg(test)]
 #[quickcheck]
 fn prop_from_int_to_int(n: Name) -> bool {
     match n {
@@ -12,7 +9,6 @@ fn prop_from_int_to_int(n: Name) -> bool {
     }
 }
 
-#[cfg(test)]
 #[quickcheck]
 fn prop_to_int_from_int(n: usize) -> bool {
     match Name::from_int(n) {

--- a/ipso-parse/src/grammar/expr/mod.rs
+++ b/ipso-parse/src/grammar/expr/mod.rs
@@ -1,5 +1,6 @@
 //! Parsing expressions
 
+#[cfg(test)]
 mod test;
 
 use crate::{

--- a/ipso-parse/src/grammar/expr/test.rs
+++ b/ipso-parse/src/grammar/expr/test.rs
@@ -1,22 +1,14 @@
-#[cfg(test)]
 use super::{expr_app, expr_case, string};
-#[cfg(test)]
 use crate::ParseError;
-#[cfg(test)]
 use crate::{keep_left, map2, Parser};
-#[cfg(test)]
 use ipso_diagnostic::Source;
-#[cfg(test)]
 use ipso_lex::{
     token::{self, Relation},
     Lexer,
 };
-#[cfg(test)]
 use ipso_syntax::{Branch, Expr, Keyword, Pattern, Spanned, StringPart};
-#[cfg(test)]
 use std::rc::Rc;
 
-#[cfg(test)]
 macro_rules! parse_test {
     ($input:expr, $function:ident, $output:expr) => {{
         assert_eq!($output, {

--- a/ipso-parse/src/grammar/module/mod.rs
+++ b/ipso-parse/src/grammar/module/mod.rs
@@ -1,5 +1,6 @@
 //! Parsing modules
 
+#[cfg(test)]
 mod test;
 
 use crate::{

--- a/ipso-parse/src/grammar/module/test.rs
+++ b/ipso-parse/src/grammar/module/test.rs
@@ -1,20 +1,13 @@
-#[cfg(test)]
 use super::{definition, from_import, import, type_alias};
-#[cfg(test)]
 use crate::{keep_left, map2, ParseError, Parser};
-#[cfg(test)]
 use ipso_diagnostic::Source;
-#[cfg(test)]
 use ipso_lex::{
     token::{self, Relation},
     Lexer,
 };
-#[cfg(test)]
 use ipso_syntax::{r#type::Type, Declaration, Expr, Names, Pattern, Spanned};
-#[cfg(test)]
 use std::rc::Rc;
 
-#[cfg(test)]
 macro_rules! parse_test {
     ($input:expr, $function:ident, $output:expr) => {{
         assert_eq!($output, {

--- a/ipso-parse/src/grammar/pattern/mod.rs
+++ b/ipso-parse/src/grammar/pattern/mod.rs
@@ -1,8 +1,7 @@
 //! Parsing patterns
 
+#[cfg(test)]
 mod test;
-
-use std::rc::Rc;
 
 use crate::{
     between, choices, indent, indent_scope, keep_right, map0, optional, spanned, ParseResult,
@@ -10,6 +9,7 @@ use crate::{
 };
 use ipso_lex::token;
 use ipso_syntax::{Pattern, Spanned};
+use std::rc::Rc;
 
 /**
 ```text

--- a/ipso-parse/src/grammar/pattern/test.rs
+++ b/ipso-parse/src/grammar/pattern/test.rs
@@ -1,17 +1,10 @@
-#[cfg(test)]
 use super::pattern;
-#[cfg(test)]
 use crate::{keep_left, map2, Parser};
-#[cfg(test)]
 use ipso_diagnostic::Source;
-#[cfg(test)]
 use ipso_lex::Lexer;
-#[cfg(test)]
 use ipso_syntax::{Pattern, Spanned};
-#[cfg(test)]
 use std::rc::Rc;
 
-#[cfg(test)]
 macro_rules! parse_test {
     ($input:expr, $function:ident, $output:expr) => {{
         assert_eq!($output, {

--- a/ipso-parse/src/grammar/type/mod.rs
+++ b/ipso-parse/src/grammar/type/mod.rs
@@ -1,5 +1,6 @@
 //! Parsing types
 
+#[cfg(test)]
 mod test;
 
 use crate::{

--- a/ipso-parse/src/grammar/type/test.rs
+++ b/ipso-parse/src/grammar/type/test.rs
@@ -1,17 +1,10 @@
-#[cfg(test)]
 use super::type_;
-#[cfg(test)]
 use crate::{keep_left, map2, Parser};
-#[cfg(test)]
 use ipso_diagnostic::Source;
-#[cfg(test)]
 use ipso_lex::Lexer;
-#[cfg(test)]
 use ipso_syntax::Type;
-#[cfg(test)]
 use std::rc::Rc;
 
-#[cfg(test)]
 macro_rules! parse_test {
     ($input:expr, $function:ident, $output:expr) => {{
         assert_eq!($output, {

--- a/ipso-parse/src/lib.rs
+++ b/ipso-parse/src/lib.rs
@@ -1,7 +1,9 @@
+#[cfg(test)]
+mod test;
+
 pub mod grammar;
 pub mod indentation;
 pub mod operator;
-mod test;
 
 use fixedbitset::FixedBitSet;
 use fnv::FnvHashSet;

--- a/ipso-parse/src/operator/test.rs
+++ b/ipso-parse/src/operator/test.rs
@@ -1,8 +1,5 @@
-#[cfg(test)]
 use crate::{operator::operator, ParseResult};
-use ipso_syntax::Spanned;
-#[cfg(test)]
-use ipso_syntax::{Binop, Expr};
+use ipso_syntax::{Binop, Expr, Spanned};
 
 #[test]
 fn all_left_associative() {

--- a/ipso-parse/src/test.rs
+++ b/ipso-parse/src/test.rs
@@ -1,15 +1,9 @@
-#[cfg(test)]
 use super::{ParseError, Parser};
-#[cfg(test)]
 use crate::{keep_left, map2};
-#[cfg(test)]
 use ipso_diagnostic::Source;
-#[cfg(test)]
 use ipso_lex::{token, Lexer};
-#[cfg(test)]
 use std::rc::Rc;
 
-#[cfg(test)]
 macro_rules! parse_test {
     ($input:expr, $function:ident, $output:expr) => {{
         assert_eq!($output, {

--- a/ipso-rope/src/lib.rs
+++ b/ipso-rope/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod test;
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/ipso-rope/src/test.rs
+++ b/ipso-rope/src/test.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 use crate::Rope;
 
 #[test]

--- a/ipso-syntax/src/lib.rs
+++ b/ipso-syntax/src/lib.rs
@@ -1,7 +1,8 @@
-pub mod desugar;
-pub mod kind;
 #[cfg(test)]
 mod test;
+
+pub mod desugar;
+pub mod kind;
 pub mod r#type;
 
 use quickcheck::Arbitrary;

--- a/ipso-syntax/src/test.rs
+++ b/ipso-syntax/src/test.rs
@@ -1,11 +1,7 @@
+use crate::{is_keyword, Keyword, Type, KEYWORDS};
+use quickcheck_macros::quickcheck;
 use std::rc::Rc;
 
-#[cfg(test)]
-use crate::{is_keyword, Keyword, Type, KEYWORDS};
-#[cfg(test)]
-use quickcheck_macros::quickcheck;
-
-#[cfg(test)]
 #[quickcheck]
 fn prop_all_keywords_in_list(keyword: Keyword) {
     let keyword_string = keyword.to_string();

--- a/ipso-typecheck/src/evidence/solver/mod.rs
+++ b/ipso-typecheck/src/evidence/solver/mod.rs
@@ -1,12 +1,11 @@
-use std::rc::Rc;
+#[cfg(test)]
+mod test;
 
+use super::Constraint;
 use crate::{metavariables, Implication, SolveConstraintContext, TypeError, Typechecker};
 use ipso_core::{self as core, Binop, Expr, Placeholder};
 use ipso_syntax::kind::Kind;
-
-use super::Constraint;
-
-mod test;
+use std::rc::Rc;
 
 pub fn lookup_evidence(tc: &Typechecker, constraint: &Constraint) -> Option<Rc<core::Expr>> {
     tc.evidence.environment.iter().find_map(

--- a/ipso-typecheck/src/evidence/solver/test.rs
+++ b/ipso-typecheck/src/evidence/solver/test.rs
@@ -1,13 +1,9 @@
-#[cfg(test)]
 use crate::{
     evidence::{solver::solve_constraint, Constraint, Evidence},
     Typechecker,
 };
-#[cfg(test)]
 use ipso_core::{self as core, Binop, ClassDeclaration, ClassMember, EVar, Expr, Name, TypeSig};
-#[cfg(test)]
 use ipso_syntax::kind::Kind;
-#[cfg(test)]
 use std::rc::Rc;
 
 #[test]

--- a/ipso-typecheck/src/kind_inference/test.rs
+++ b/ipso-typecheck/src/kind_inference/test.rs
@@ -1,12 +1,7 @@
-#[cfg(test)]
 use super::{infer, InferenceContext, InferenceError, InferenceErrorHint, Solutions};
-#[cfg(test)]
 use crate::BoundVars;
-#[cfg(test)]
 use ipso_core::{self as core, CommonKinds};
-#[cfg(test)]
 use ipso_syntax::{self as syntax, kind::Kind};
-#[cfg(test)]
 use std::collections::HashMap;
 use std::rc::Rc;
 

--- a/ipso-typecheck/src/lib.rs
+++ b/ipso-typecheck/src/lib.rs
@@ -1,8 +1,9 @@
+#[cfg(test)]
+mod test;
+
 pub mod evidence;
 pub mod kind_inference;
 pub mod metavariables;
-#[cfg(test)]
-mod test;
 pub mod type_inference;
 
 use diagnostic::{Location, Message};

--- a/ipso-typecheck/src/test.rs
+++ b/ipso-typecheck/src/test.rs
@@ -1,17 +1,11 @@
-#[cfg(test)]
 use crate::{
     evidence::{solver::solve_placeholder, Constraint},
     BoundVars, Declarations, Typechecker,
 };
-#[cfg(test)]
 use ipso_core::{self as core, ClassMember, Placeholder, TypeSig};
-#[cfg(test)]
 use ipso_syntax::{kind::Kind, r#type::Type, ModuleId, Spanned};
-#[cfg(test)]
 use ipso_util::void::Void;
-#[cfg(test)]
 use std::collections::HashSet;
-#[cfg(test)]
 use std::rc::Rc;
 
 #[test]


### PR DESCRIPTION
Closes #157 