### PR TITLE
Track REPL cursor position correctly in presence of newlines

### DIFF
--- a/ipso-repl/src/lib.rs
+++ b/ipso-repl/src/lib.rs
@@ -16,7 +16,7 @@ use ipso_typecheck::{
 };
 use std::{
     collections::HashMap,
-    io::{self, BufReader, BufWriter},
+    io::{self, BufReader, Write},
     rc::Rc,
 };
 
@@ -144,7 +144,11 @@ impl Repl {
         Ok(ty)
     }
 
-    pub fn eval_show(&self, expr: Spanned<ipso_syntax::Expr>) -> Result<Option<String>, Error> {
+    pub fn eval_show(
+        &self,
+        stdout: &mut dyn Write,
+        expr: Spanned<ipso_syntax::Expr>,
+    ) -> Result<Option<String>, Error> {
         let mut expr = desugar_expr(&self.source, expr)?;
         rewrite_module_accessors_expr(&mut Default::default(), &self.imported_items, &mut expr);
 
@@ -266,14 +270,11 @@ impl Repl {
         let stdin = io::stdin();
         let mut stdin = BufReader::new(stdin);
 
-        let stdout = io::stdout();
-        let mut stdout = BufWriter::new(stdout);
-
         let context = Default::default();
 
         let mut interpreter = Interpreter::new(
             &mut stdin,
-            &mut stdout,
+            stdout,
             &self.common_kinds,
             &self.modules,
             &context,


### PR DESCRIPTION
Closes #203 

[`render_error`](https://github.com/LightAndLight/ipso/compare/issue/203?expand=1#diff-b3d9283df315e878d4df66e136fb5752456f55f821e2a9f89c8f9a760ab6ddf2R165) wrote two lines to stdout, but the REPL's cursor wasn't updated accordingly. This caused the prompt to render over the second error line. I realised that I could trigger similar behaviour by `print`ing a string containing newlines.