### PR TITLE
Fix typo in examples

### DIFF
--- a/site/pages/docs/reference.md
+++ b/site/pages/docs/reference.md
@@ -286,7 +286,7 @@ hello!
 
 ```ipsorepl
 > let args = ["hello", "world"]
-> `echo $arg`
+> `echo $args`
 `echo hello world`
 ```
 


### PR DESCRIPTION
There is a typo in the example.