### PR TITLE
Use `pueue` to manage Nix cache uploads

### DIFF
--- a/.github/workflows/ipso-cli.yml
+++ b/.github/workflows/ipso-cli.yml
@@ -11,6 +11,11 @@ env:
   # Note: these values are duplicated in the `UPLOAD_TO_CACHE` script.
   BINARY_CACHE_BUCKET: "ipso-binary-cache"
   BINARY_CACHE_ENDPOINT: "7065dc7f7d1813a29036535b4c4f4014.r2.cloudflarestorage.com"
+
+  # Avoid [rate
+  # limiting](https://discourse.nixos.org/t/flakes-provide-github-api-token-for-rate-limiting/18609)
+  # by allowing Nix to make authenticated GitHub requests.
+  NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ipso-cli.yml
+++ b/.github/workflows/ipso-cli.yml
@@ -15,51 +15,111 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     env:
+      POST_BUILD_HOOK: ".github/workflows/postBuildHook"
       UPLOAD_TO_CACHE: ".github/workflows/uploadToCache"
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15
 
-    # Allows `uploadToCache` to sign store paths.
+    # Used by `uploadToCache` to sign store paths.
     - run: "sudo bash -c 'echo \"${{ secrets.NIX_SIGNING_KEY }}\" > /run/nix-signing-key'"
 
-    # Grants the Nix daemon access to the bucket, which allows `nix build` to 
-    # authenticate with the binary cache bucket.
+    # Grants the Nix daemon access to the bucket, which allows `nix build` to
+    # authenticate with the binary cache bucket and fetch cache items.
     - run: sudo mkdir /root/.aws
     - run: "sudo bash -c 'echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > /root/.aws/credentials'"
 
-    # Allow the Nix daemon to execute the upload script.
-    - run: "sudo chmod +x $UPLOAD_TO_CACHE"
+    # Grants the runner access to the bucket, which allows `pueue` to
+    # authenticate with the binary cache bucket when pushing signed cache items.
+    - run: sudo mkdir ~/.aws
+    - run: sudo chown runner ~/.aws
+    - run: "echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID}}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > ~/.aws/credentials"
 
-    - run: nix build --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT" --extra-trusted-public-keys "$NIX_PUBLIC_KEY" --post-build-hook "$GITHUB_WORKSPACE/$UPLOAD_TO_CACHE" -o result
-    
+    # Allow the Nix daemon to execute the post-build-hook script.
+    - run: "sudo chmod +x $POST_BUILD_HOOK"
+
+    # Used in `postBuildHook`.
+    - run: sudo cp $UPLOAD_TO_CACHE /run/uploadToCache
+
+    - run: nix profile install nixpkgs#pueue
+    - run: pueued -d
+
+    - run: >
+        nix build
+        --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT"
+        --extra-trusted-public-keys "$NIX_PUBLIC_KEY"
+        --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
+        -o result
+
+    - name: wait for uploads to finish
+      if: always()
+      run: pueue wait
+
+    - name: log failed uploads
+      if: always()
+      run: pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != "Success") | .key' -r | xargs -r pueue log
+
+    - name: check uploads succeeded
+      if: always()
+      run: "[ \"$(pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != \"Success\") | .key' -r)\" == \"\" ]"
+
     - run: cp result-bin/bin/ipso ipso-linux-x86_64
     - uses: actions/upload-artifact@v3
       with:
         name: ipso-linux-x86_64
         path: ipso-linux-x86_64
-  
+
   build-macos:
     runs-on: macos-latest
     env:
+      POST_BUILD_HOOK: ".github/workflows/postBuildHookMacos"
       UPLOAD_TO_CACHE: ".github/workflows/uploadToCacheMacos"
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15
 
-    # Allows `uploadToCache` to sign store paths.
+    # Used by `uploadToCache` to sign store paths.
     - run: "sudo bash -c 'echo \"${{ secrets.NIX_SIGNING_KEY }}\" > /var/run/nix-signing-key'"
 
-    # Grants the Nix daemon access to the bucket, which allows `nix build` to 
-    # authenticate with the binary cache bucket.
+    # Grants the Nix daemon access to the bucket, which allows `nix build` to
+    # authenticate with the binary cache bucket and fetch cache items.
     - run: sudo mkdir /var/root/.aws
     - run: "sudo bash -c 'echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > /var/root/.aws/credentials'"
 
-    # Allow the Nix daemon to execute the upload script.
-    - run: "sudo chmod +x $UPLOAD_TO_CACHE"
+    # Grants the runner access to the bucket, which allows `pueue` to
+    # authenticate with the binary cache bucket when pushing signed cache items.
+    - run: sudo mkdir ~/.aws
+    - run: sudo chown runner ~/.aws
+    - run: "echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID}}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > ~/.aws/credentials"
 
-    - run: nix build --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT" --extra-trusted-public-keys "$NIX_PUBLIC_KEY" --post-build-hook "$GITHUB_WORKSPACE/$UPLOAD_TO_CACHE" -o result
-    
+    # Allow the Nix daemon to execute the post-build-hook script.
+    - run: "sudo chmod +x $POST_BUILD_HOOK"
+
+    # Used in `postBuildHookMacos`.
+    - run: sudo cp $UPLOAD_TO_CACHE /var/run/uploadToCache
+
+    - run: nix profile install nixpkgs#pueue
+    - run: pueued -d
+
+    - run: >
+        nix build
+        --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT"
+        --extra-trusted-public-keys "$NIX_PUBLIC_KEY"
+        --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
+        -o result
+
+    - name: wait for uploads to finish
+      if: always()
+      run: pueue wait
+
+    - name: log failed uploads
+      if: always()
+      run: pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != "Success") | .key' -r | xargs -r pueue log
+
+    - name: check uploads succeeded
+      if: always()
+      run: "[ \"$(pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != \"Success\") | .key' -r)\" == \"\" ]"
+
     - run: cp result-bin/bin/ipso ipso-macos-x86_64
     - uses: actions/upload-artifact@v3
       with:
@@ -71,34 +131,66 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
+      POST_BUILD_HOOK: ".github/workflows/postBuildHook"
       UPLOAD_TO_CACHE: ".github/workflows/uploadToCache"
-   
+
     steps:
     - uses: actions/checkout@v2.4.0
 
     # Nix setup
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15
+
+    # Used by `uploadToCache` to sign store paths.
     - run: "sudo bash -c 'echo \"${{ secrets.NIX_SIGNING_KEY }}\" > /run/nix-signing-key'"
+
+    # Grants the Nix daemon access to the bucket, which allows `nix build` to
+    # authenticate with the binary cache bucket and fetch cache items.
     - run: sudo mkdir /root/.aws
     - run: "sudo bash -c 'echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > /root/.aws/credentials'"
-    - run: "sudo chmod +x $UPLOAD_TO_CACHE"
+
+    # Grants the runner access to the bucket, which allows `pueue` to
+    # authenticate with the binary cache bucket when pushing signed cache items.
+    - run: sudo mkdir ~/.aws
+    - run: sudo chown runner ~/.aws
+    - run: "echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID}}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > ~/.aws/credentials"
+
+    # Allow the Nix daemon to execute the post-build-hook script.
+    - run: "sudo chmod +x $POST_BUILD_HOOK"
+
+    # Used in `postBuildHook`.
+    - run: sudo cp $UPLOAD_TO_CACHE /run/uploadToCache
+
+    - run: nix profile install nixpkgs#pueue
+    - run: pueued -d
 
     - name: Check release version
       run: >
         nix shell
-        --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT" 
+        --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT"
         --extra-trusted-public-keys "$NIX_PUBLIC_KEY"
-        --post-build-hook "$GITHUB_WORKSPACE/$UPLOAD_TO_CACHE"
+        --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
         -c .github/workflows/checkReleaseVersion
 
     - uses: actions/download-artifact@v3
       with:
         name: ipso-linux-x86_64
-    
+
     - uses: actions/download-artifact@v3
       with:
         name: ipso-macos-x86_64
+
+    - name: wait for uploads to finish
+      if: always()
+      run: pueue wait
+
+    - name: log failed uploads
+      if: always()
+      run: pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != "Success") | .key' -r | xargs -r pueue log
+
+    - name: check uploads succeeded
+      if: always()
+      run: "[ \"$(pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != \"Success\") | .key' -r)\" == \"\" ]"
 
     - uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/postBuildHook
+++ b/.github/workflows/postBuildHook
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+su -l runner -c "/nix/var/nix/profiles/per-user/runner/profile/bin/pueue add -- OUT_PATHS=\"$OUT_PATHS\" /run/uploadToCache"

--- a/.github/workflows/postBuildHookMacos
+++ b/.github/workflows/postBuildHookMacos
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+su -l runner -c "/nix/var/nix/profiles/per-user/runner/profile/bin/pueue add -- OUT_PATHS=\"$OUT_PATHS\" /var/run/uploadToCache"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,42 +11,66 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
-      UPLOAD_TO_CACHE: ".github/workflows/uploadToCache"
+      POST_BUILD_HOOK: ".github/workflows/postBuildHook"
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: cachix/install-nix-action@v15
 
-    # Allows `uploadToCache` to sign store paths.
+    # Used by `uploadToCache` to sign store paths.
     - run: "sudo bash -c 'echo \"${{ secrets.NIX_SIGNING_KEY }}\" > /run/nix-signing-key'"
 
-    # Grants the Nix daemon access to the bucket, which allows `nix build` to 
-    # authenticate with the binary cache bucket.
+    # Grants the Nix daemon access to the bucket, which allows `nix build` to
+    # authenticate with the binary cache bucket and fetch cache items.
     - run: sudo mkdir /root/.aws
     - run: "sudo bash -c 'echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > /root/.aws/credentials'"
 
-    # Allow the Nix daemon to execute the upload script.
-    - run: "sudo chmod +x $UPLOAD_TO_CACHE"
+    # Grants the runner access to the bucket, which allows `pueue` to
+    # authenticate with the binary cache bucket when pushing signed cache items.
+    - run: sudo mkdir ~/.aws
+    - run: sudo chown runner ~/.aws
+    - run: "echo -e \"[default]\naws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID}}\naws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}\" > ~/.aws/credentials"
+
+    # Allow the Nix daemon to execute the post-build-hook script.
+    - run: "sudo chmod +x $POST_BUILD_HOOK"
+
+    # Used in `postBuildHook`.
+    - run: sudo cp .github/workflows/uploadToCache /run/uploadToCache
+
+    - run: nix profile install nixpkgs#pueue
+    - run: pueued -d
 
     - name: "cargo tests"
       run: >
         nix develop .#tests
         --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT"
         --extra-trusted-public-keys "$NIX_PUBLIC_KEY"
-        --post-build-hook "$GITHUB_WORKSPACE/$UPLOAD_TO_CACHE"
+        --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
         -c cargo test
-    
+
     - name: "golden tests"
       run: >
-        nix develop .#tests 
+        nix develop .#tests
         --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT"
         --extra-trusted-public-keys "$NIX_PUBLIC_KEY"
-        --post-build-hook "$GITHUB_WORKSPACE/$UPLOAD_TO_CACHE"
+        --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
         -c ./scripts/golden
-    
+
     - name: "shebang tests"
       run: >
         nix develop .#tests
         --extra-substituters "s3://$BINARY_CACHE_BUCKET?scheme=https&endpoint=$BINARY_CACHE_ENDPOINT"
         --extra-trusted-public-keys "$NIX_PUBLIC_KEY"
-        --post-build-hook "$GITHUB_WORKSPACE/$UPLOAD_TO_CACHE"
+        --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
         -c ./scripts/shebang
+
+    - name: wait for uploads to finish
+      if: always()
+      run: pueue wait
+
+    - name: log failed uploads
+      if: always()
+      run: pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != "Success") | .key' -r | xargs -r pueue log
+
+    - name: check uploads succeeded
+      if: always()
+      run: "[ \"$(pueue log --json | jq 'to_entries[] | select(.value.task.status.Done != \"Success\") | .key' -r)\" == \"\" ]"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,11 @@ env:
   # Note: these values are duplicated in the `UPLOAD_TO_CACHE` script.
   BINARY_CACHE_BUCKET: "ipso-binary-cache"
   BINARY_CACHE_ENDPOINT: "7065dc7f7d1813a29036535b4c4f4014.r2.cloudflarestorage.com"
+
+  # Avoid [rate
+  # limiting](https://discourse.nixos.org/t/flakes-provide-github-api-token-for-rate-limiting/18609)
+  # by allowing Nix to make authenticated GitHub requests.
+  NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I had a hard time implementing https://github.com/LightAndLight/ipso/issues/271 because I couldn't see why my changes to the post-build-hook were failing.

This PR has the post-build-hook call out to [pueue](https://github.com/Nukesor/pueue) in a way that lets me show the logs for failed post-build-hook calls.