### PR TITLE
build: allow golden tests to be skipped

### DIFF
--- a/examples/__skip.dhall
+++ b/examples/__skip.dhall
@@ -1,0 +1,3 @@
+[
+  -- { name = "test name", reason = "reason you're skipping it" }
+] : List { name : Text, reason : Text }

--- a/tests/common/src/Test/Ipso/Common.hs
+++ b/tests/common/src/Test/Ipso/Common.hs
@@ -2,7 +2,6 @@
 
 module Test.Ipso.Common (runDiff, eqExitCode, displayError, Config (..), configParser, examplesMain) where
 
-import qualified Data.Either as Either
 import Data.Foldable (traverse_)
 import qualified Data.List as List
 import Data.Text (Text)
@@ -11,7 +10,7 @@ import qualified Data.Text.IO as Text.IO
 import Data.Traversable (for)
 import qualified Dhall
 import Options.Applicative (Parser, ReadM, execParser, fullDesc, help, info, long, metavar, option, str, strOption, value)
-import System.Directory (getCurrentDirectory, listDirectory, setCurrentDirectory)
+import System.Directory (doesFileExist, getCurrentDirectory, listDirectory, setCurrentDirectory)
 import System.Exit (ExitCode (..), exitFailure, exitSuccess)
 import System.FilePath (takeBaseName, takeExtension, (</>))
 import qualified System.IO
@@ -86,6 +85,33 @@ configParser curDir restParser =
       )
     <*> restParser
 
+data SkipListEntry = SkipListEntry { skipListEntryName :: String, skipListEntryReason :: String }
+  deriving Show
+
+skipListDecoder :: Dhall.Decoder [SkipListEntry]
+skipListDecoder =
+  Dhall.list . Dhall.record $
+    SkipListEntry
+      <$> Dhall.field "name" Dhall.string
+      <*> Dhall.field "reason" Dhall.string
+
+shouldSkip :: [SkipListEntry] -> String -> Maybe String
+shouldSkip skipListEntries name =
+  skipListEntryReason <$> List.find (\entry -> skipListEntryName entry == name) skipListEntries
+
+data Result a = Success a | Failure String | Skip String
+
+partitionResults :: [Result a] -> ([a], [String], [String])
+partitionResults = 
+  foldr 
+    (\item (successes, failures, skips) ->
+      case item of
+        Success success -> (success : successes, failures, skips)
+        Failure failure -> (successes, failure : failures, skips)
+        Skip skip -> (successes, failures, skip : skips)
+    )
+    ([], [], [])
+
 examplesMain ::
   Parser a ->
   (FilePath -> Dhall.Decoder example) ->
@@ -95,19 +121,40 @@ examplesMain restParser exampleDecoder runExample = do
   curDir <- getCurrentDirectory
   config <- execParser (info (configParser curDir restParser) fullDesc)
   setCurrentDirectory $ cfgDir config
+
+  let skipListFile = "__skip.dhall"
+  skipListFileExists <- doesFileExist skipListFile
+  skipList <-
+    if skipListFileExists
+      -- Assumes `skipList` has very few lines. For better performance use a set with O(log n) membership.
+      then Dhall.inputFile skipListDecoder skipListFile
+      else pure []
+  
   files <- listDirectory "."
+  
   let filterOnly =
         case cfgOnly config of
           Nothing ->
             const True
           Just names ->
             \file -> takeBaseName file `elem` names
-  results <- for (List.sort $ filter (\file -> ".dhall" == takeExtension file && filterOnly file) files) $ \file -> do
-    example <- Dhall.inputFile (exampleDecoder file) file
-    runExample config example
-  let (failures, successes) = Either.partitionEithers results
+  
+  results <- for (List.sort $ filter (\file -> ".dhall" == takeExtension file && filterOnly file && file /= skipListFile) files) $ \file -> do
+    let testName = takeBaseName file
+    case shouldSkip skipList testName of
+      Nothing -> do
+        example <- Dhall.inputFile (exampleDecoder file) file
+        either Failure Success <$> runExample config example
+      Just reason -> do
+        putStrLn $ "skipping " <> testName <> ": " <> reason
+        pure $ Skip reason
+  
+  let (successes, failures, skips) = partitionResults results
+
+  if null skips then pure () else putStrLn ""
   putStrLn $ show (length successes) <> " examples passed"
   putStrLn $ show (length failures) <> " examples failed"
+  putStrLn $ show (length skips) <> " examples skipped"
   putStrLn ""
   traverse_ putStr failures
   case failures of


### PR DESCRIPTION
I'm shipping a feature that breaks some golden tests. I want to merge it and then work on another feature that will fix the broken tests. In the meantime, I'd like to disable the golden tests with a reminder to reactivate them.