### PR TITLE
build: bump Rust version to 1.69.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           ];
         };
 
-        rustVersion = "1.62.1";
+        rustVersion = "1.69.0";
         
         rustPkgs = { release }: pkgs.rustBuilder.makePackageSet {
           rustChannel = rustVersion;


### PR DESCRIPTION
I ran into an issue like [this](https://github.com/rust-lang/rust-analyzer/issues/14554), and upgrading Rust fixed it.