### PR TITLE
build: fix post build hook

### DIFF
--- a/.github/workflows/postBuildHook
+++ b/.github/workflows/postBuildHook
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-su -l runner -c "env PATH=\"\$PATH:\$HOME/bin\" pueue add -- OUT_PATHS=\"$OUT_PATHS\" /run/uploadToCache"
+su -l runner -c "env PATH=\"\$PATH:\$HOME/bin\" pueue add -- OUT_PATHS=\\\"$OUT_PATHS\\\" /run/uploadToCache"

--- a/.github/workflows/postBuildHookMacos
+++ b/.github/workflows/postBuildHookMacos
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-su -l runner -c "env PATH=\"\$PATH:\$HOME/bin\" \$(readlink \$HOME/.nix-profile)/bin/pueue add -- OUT_PATHS=\"$OUT_PATHS\" /var/run/uploadToCache"
+su -l runner -c "env PATH=\"\$PATH:\$HOME/bin\" \$(readlink \$HOME/.nix-profile)/bin/pueue add -- OUT_PATHS=\\\"$OUT_PATHS\\\" /var/run/uploadToCache"


### PR DESCRIPTION
If you look past all those backslashes, the post build hook is adding the command `OUT_PATHS=$OUT_PATHS /run/uploadToCache` to the queue (where `$OUT_PATHS` has been substituted for the actual value). This only works when `$OUT_PATHS` contains no spaces.

As an example, running `pueue add -- VAR="hello world" printenv VAR` adds the command `VAR=hello world printenv VAR` to the queue, which is not what we want. The queue tries to run a command called `world` with arguments `printenv` and `VAR`. The problem is that the quotes around the variable aren't carried onto the queue.  We need to run `pueue add -- VAR=\"hello world\" printenv VAR` so that the queue executes `VAR="hello world" printenv VAR`.