### PR TITLE
build: bump download-artifact to v4

### DIFF
--- a/.github/workflows/ipso-cli.yml
+++ b/.github/workflows/ipso-cli.yml
@@ -231,11 +231,11 @@ jobs:
         --post-build-hook "$GITHUB_WORKSPACE/$POST_BUILD_HOOK"
         -c .github/workflows/checkReleaseVersion
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ipso-linux-x86_64
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ipso-macos-x86_64
 


### PR DESCRIPTION
Reason: <https://github.com/advisories/GHSA-cxww-7g56-2vh6>